### PR TITLE
Set SuppressDevAppServerLog option in aetest

### DIFF
--- a/testarator.go
+++ b/testarator.go
@@ -77,7 +77,11 @@ func (s *Setup) SpinUp() error {
 		return nil
 	}
 
-	opt := &aetest.Options{AppID: "unittest", StronglyConsistentDatastore: true}
+	opt := &aetest.Options{
+		AppID: "unittest",
+		StronglyConsistentDatastore: true,
+		SuppressDevAppServerLog:     true,
+	}
 	inst, err := aetest.NewInstance(opt)
 	if err != nil {
 		return err


### PR DESCRIPTION
The latest appengine supports an option to suppress annoying logs in
tests.  This patch enables it.

https://github.com/golang/appengine/pull/119