### PR TITLE
Claeanup datastore under all namespaces

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -1,7 +1,10 @@
 package datastore
 
 import (
+	"context"
+
 	"github.com/favclip/testerator"
+	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 )
 
@@ -10,7 +13,34 @@ func init() {
 }
 
 func cleanup(s *testerator.Setup) error {
-	t := datastore.NewQuery("__kind__").KeysOnly().Run(s.Context)
+	contexts := []context.Context{s.Context}
+
+	q := datastore.NewQuery("__namespace__").KeysOnly()
+	namespaces, err := q.GetAll(s.Context, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, ns := range namespaces {
+		nsContext, err := appengine.Namespace(s.Context, ns.StringID())
+		if err != nil {
+			return err
+		}
+		contexts = append(contexts, nsContext)
+	}
+
+	for _, ctx := range contexts {
+		err := cleanupUnderContext(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func cleanupUnderContext(ctx context.Context) error {
+	t := datastore.NewQuery("__kind__").KeysOnly().Run(ctx)
 	kinds := make([]string, 0)
 	for {
 		key, err := t.Next(nil)
@@ -25,11 +55,11 @@ func cleanup(s *testerator.Setup) error {
 
 	for _, kind := range kinds {
 		q := datastore.NewQuery(kind).KeysOnly()
-		keys, err := q.GetAll(s.Context, nil)
+		keys, err := q.GetAll(ctx, nil)
 		if err != nil {
 			return err
 		}
-		err = datastore.DeleteMulti(s.Context, keys)
+		err = datastore.DeleteMulti(ctx, keys)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
`datastore.cleanup()` deletes entities only under default namespace. If application code uses namespaces other than default, entities keep remain after cleanup and they cause test failures.

So I updated cleanup code to cleanup all namespaces.

Please check it.

